### PR TITLE
Fix Repo address should be parsed even without `.git` at the end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitopen"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["Oren Epshtain"]
 edition = "2018"
 license-file = "LICENSE"


### PR DESCRIPTION
Fixes https://github.com/oren0e/gitopen/issues/10